### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Contributions of all kinds are welcome for all Suborbital projects. There are two rules that must be adhered to when making contributions:
+
+1. All interaction with Suborbital on GitHub or in other public online spaces such as [Discord](https://chat.suborbital.dev) or [Twitter](https://twitter.com/suborbitaldev) must follow the [Contributor Covenant Code of Conduct](https://github.com/suborbital/meta/blob/master/CODE_OF_CONDUCT.md) which is kept up to date in the `suborbital/meta` repository, and linked to here.
+
+2. Any code contributions must be preceded by a discussion that takes place in a GitHub issue for the associated repo(s). Please do not submit Pull Requests before first creating an issue and discussing it with the Suborbital team or using an existing issue. This includes all changes to the contents of Suborbital Git repositories, except for the following content: documentation, README errors, additional automated tests, and additional clarifying information such as comments. The Suborbital team can choose to close any Pull Request that does not have an appropriate issue.
+
+Beyond all else please be kind, and welcome to the Suborbital family of projects! We're really glad you're here.


### PR DESCRIPTION
Closes Issue #8 (which in turns resolves parts of [Issue #82  in the docs repo](https://github.com/suborbital/docs/issues/82)).  This file will be linked to from all other CONTRIBUTING.md pages in public repos, so we only need to maintain one.

Later we'll make additions for [Issue #3 in the docs repo](https://github.com/suborbital/docs/issues/3).