### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-Contributions of all kinds and from folks of all experience levels are welcome for all Suborbital projects! Please check out [our website's Contributions page](https://docs.suborbital.dev/contributing-guide/contributing-to-suborbital). 
+Contributions of all kinds and from folks of all experience levels are welcome for all Suborbital projects! Please check out [our website's Contributions page](https://docs.suborbital.dev/contributing/contributing-to-suborbital).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,3 @@
 # Contributing
 
-Contributions of all kinds are welcome for all Suborbital projects. There are two rules that must be adhered to when making contributions:
-
-1. All interaction with Suborbital on GitHub or in other public online spaces such as [Discord](https://chat.suborbital.dev) or [Twitter](https://twitter.com/suborbitaldev) must follow the [Contributor Covenant Code of Conduct](https://github.com/suborbital/meta/blob/master/CODE_OF_CONDUCT.md) which is kept up to date in the `suborbital/meta` repository, and linked to here.
-
-2. Any code contributions must be preceded by a discussion that takes place in a GitHub issue for the associated repo(s). Please do not submit Pull Requests before first creating an issue and discussing it with the Suborbital team or using an existing issue. This includes all changes to the contents of Suborbital Git repositories, except for the following content: documentation, README errors, additional automated tests, and additional clarifying information such as comments. The Suborbital team can choose to close any Pull Request that does not have an appropriate issue.
-
-Beyond all else please be kind, and welcome to the Suborbital family of projects! We're really glad you're here.
+Contributions of all kinds and from folks of all experience levels are welcome for all Suborbital projects! Please check out [our website's Contributions page](https://docs.suborbital.dev/contributing-guide/contributing-to-suborbital). 


### PR DESCRIPTION
For /docs Issue 82. The previous iteration of this file established this file as the canonical page for contribution information, but it should actually be the contributions page on the website that is the canonical source.